### PR TITLE
added missing gflags include (for DEFINE_bool)

### DIFF
--- a/src/cuda/fft/CuFFTWrapper.cu
+++ b/src/cuda/fft/CuFFTWrapper.cu
@@ -17,6 +17,7 @@
 #include <thrust/fill.h>
 #include <thrust/replace.h>
 #include <thrust/functional.h>
+#include <gflags/gflags.h>
 
 DEFINE_bool(fft_verbose, false, "Dump meta information for the FFT wrapper");
 


### PR DESCRIPTION
This fixes this compilation error:
```
/home/mikael/oss/ms-fbcunn/src/cuda/fft/CuFFTWrapper.cu(21): error: this declaration has no storage class or type specifier

/home/mikael/oss/ms-fbcunn/src/cuda/fft/CuFFTWrapper.cu(21): error: identifier "fft_verbose" is undefined

/home/mikael/oss/ms-fbcunn/src/cuda/fft/CuFFTWrapper.cu(21): error: expected a ")"

/home/mikael/oss/ms-fbcunn/src/cuda/fft/CuFFTWrapper.cu(76): error: identifier "FLAGS_fft_verbose" is undefined
```