### PR TITLE
simplified optimState update for different regimes

### DIFF
--- a/examples/imagenet/train.lua
+++ b/examples/imagenet/train.lua
@@ -83,7 +83,7 @@ function train()
    print("==> online epoch # " .. epoch)
 
    local params, newRegime = paramsForEpoch(epoch)
-   if newRegime then
+   if newRegime or not optimator then
       -- Update optimState
       splice(optimState, params)
       -- Zero the momentum vector by throwing away previous state.

--- a/src/cuda/fft/CuFFTWrapper.cu
+++ b/src/cuda/fft/CuFFTWrapper.cu
@@ -17,6 +17,7 @@
 #include <thrust/fill.h>
 #include <thrust/replace.h>
 #include <thrust/functional.h>
+#include <gflags/gflags.h>
 
 DEFINE_bool(fft_verbose, false, "Dump meta information for the FFT wrapper");
 


### PR DESCRIPTION
The original implementation calls ```optimator:setParameters(params)``` for each epoch. This does not seem necessary. This had the side effect of modifying the local variable ```optimState``` which was then used to instantiate a new ```nn.Optim()``` when changing to a new regime. 

I may be missing something but I think it is more straightforward to explicitly update ```optimState```.