### PR TITLE
Finishing dynamic k-max pooling

### DIFF
--- a/src/TemporalKMaxPoolingHost.cpp
+++ b/src/TemporalKMaxPoolingHost.cpp
@@ -22,7 +22,7 @@ int checkAndAdjustK(lua_State* L, int k, double kDynamic, long sequenceLength) {
   }
 
   if (k > sequenceLength) {
-    luaL_error(L, "k: k must be less than the sequence length");
+    luaL_error(L, "k (%d) must be less than sequence length (%d) ", k, sequenceLength);
   }
 
   return k;
@@ -60,7 +60,7 @@ int cunn_TemporalKMaxPooling_updateOutput(lua_State *L) {
   auto inputContiguousTH = THCudaTensor_newContiguous(state, inputTH);
   SCOPE_EXIT{ THCudaTensor_free(state, inputContiguousTH); };
 
-  checkAndAdjustK(L, k, kDynamic, sequenceLength);
+  k = checkAndAdjustK(L, k, kDynamic, sequenceLength);
 
   DeviceTensor<float, 3> input;
   DeviceTensor<float, 3> indices;
@@ -143,7 +143,7 @@ int cunn_TemporalKMaxPooling_updateGradInput(lua_State *L) {
   }
 
   const auto sequenceLength = gradInput.getSize(1);
-  checkAndAdjustK(L, k, kDynamic, sequenceLength);
+  k = checkAndAdjustK(L, k, kDynamic, sequenceLength);
 
   runTemporalKMaxPoolingUpdateGradInput(
     THCState_getCurrentStream(state), gradOutput, indices, gradInput, k);

--- a/test/test_TemporalKMaxPooling.lua
+++ b/test/test_TemporalKMaxPooling.lua
@@ -166,5 +166,19 @@ function TemporalKMaxPoolingTest.sequential()
    assert (gradInput_matches:sum() == gradInput_matches:numel())
 end
 
+function TemporalKMaxPoolingTest.dynamic()
+  local kmax = nn.TemporalKMaxPooling(2, 0.5)
+  local seq = nn.Sequential()
+  seq:add(nn.TemporalKMaxPooling(2, 0.5))
+
+  for n=12,13 do
+    local input = torch.randn(n, 1):cuda()
+    local kmax_output = kmax:updateOutput(input)
+    local seq_output = seq:updateOutput(input)
+    assert (kmax_output:size(1) == 6)
+    assert (torch.all(kmax_output:eq(seq_output)))
+  end
+end
+
 tester:add(TemporalKMaxPoolingTest)
 tester:run()


### PR DESCRIPTION
The dynamic k-max pooling feature was only partially implemented and wasn't yet functional.  This PR makes the feature work by changing TemporalKMaxPoolingHost.cpp so that the return value of checkAndAdjustK is no longer ignored. It also adds a unit test for the feature and makes one of the error messages in the .cpp file a bit more helpful.


