### PR TITLE
Update fbcunn-scm-1.rockspec

### DIFF
--- a/rocks/fbcunn-scm-1.rockspec
+++ b/rocks/fbcunn-scm-1.rockspec
@@ -18,6 +18,8 @@ dependencies = {
    "nn >= 1.0",
    "cutorch >= 1.0",
    "multikey"
+   "fbnn"
+   "fbtorch"
 }
 
 build = {

--- a/rocks/fbcunn-scm-1.rockspec
+++ b/rocks/fbcunn-scm-1.rockspec
@@ -17,8 +17,8 @@ dependencies = {
    "torch >= 7.0",
    "nn >= 1.0",
    "cutorch >= 1.0",
-   "multikey"
-   "fbnn"
+   "multikey",
+   "fbnn",
    "fbtorch"
 }
 


### PR DESCRIPTION
Add two dependecies to ensure fbnn and fbtorch are installed and avoid runtime errors about requesting failure. 